### PR TITLE
Fixes link to point to the Sixty North GitHub repo.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Build Status](https://travis-ci.org/abingham/python-transducers.png)](https://travis-ci.org/abingham/python-transducers)
 [![Code health](https://landscape.io/github/abingham/python-transducers/master/landscape.png)](https://landscape.io/github/abingham/python-transducers)
 
-**NOTE:** This project is going to sleep for the forseeable future. Active development of these ideas will take place [over here](https://bitbucket.org/sixty-north/python-transducers).
+**NOTE:** This project is going to sleep for the forseeable future. Active development of these ideas will take place [over here](https://github.com/sixty-north/python-transducers).
 
 ==================
 python-transducers


### PR DESCRIPTION
The 'over here' link used to point to Butbucket. Now it points to the Sixty North GitHub repo.  I wouldn't bother normally, but _this_ repo is hogging the second spot for 'python transducer' on Google!
